### PR TITLE
Allow parameter array and map containers

### DIFF
--- a/src/model/utils.js
+++ b/src/model/utils.js
@@ -10,7 +10,7 @@ exports.ipv4Re = [
 ]
 exports.maxPath = 256
 exports.pathRe = [
-  /^\/[\w/-]*$/,
+  /^\/[\w/\-\]\[]*$/,
   'global path format -> \'/path/to/resource-0\'',
 ]
 exports.maxUri = 256

--- a/src/model/vapor/param.js
+++ b/src/model/vapor/param.js
@@ -13,6 +13,7 @@ const param = new mongoose.Schema({
   keyPath: {
     type: String,
     index: true,
+    unique: true,
     required: true,
     maxlength: validate.maxPath,
     match: validate.pathRe,
@@ -22,6 +23,7 @@ const param = new mongoose.Schema({
     enum: ['null', 'string', 'number', 'boolean'],
     required: true,
   },
+  isArrayItem : {type: Boolean, default: false},
   stringValue: {
     type: String,
     validate: {
@@ -44,14 +46,14 @@ const param = new mongoose.Schema({
   },
   creatorPath: {
     type: String,
-    index: true,
+    //index: true,
     required: true,
     maxlength: validate.maxPath,
     match: validate.pathRe,
   },
   creatorIpv4: {
     type: String,
-    index: true,
+    //index: true,
     required: true,
     match: validate.ipv4Re,
   },

--- a/src/model/vapor/param.js
+++ b/src/model/vapor/param.js
@@ -20,10 +20,13 @@ const param = new mongoose.Schema({
   },
   valueType: {
     type: String,
-    enum: ['null', 'string', 'number', 'boolean'],
+    enum: ['null', 'string', 'number', 'boolean', 'array'],
     required: true,
   },
-  isArrayItem : {type: Boolean, default: false},
+  arrayValue: {
+    type: mongoose.Schema.Types.Mixed,
+    required: function () { return this.valueType === 'array' }
+  },
   stringValue: {
     type: String,
     validate: {
@@ -38,11 +41,11 @@ const param = new mongoose.Schema({
   },
   numberValue: {
     type: Number,
-    required: function () { return this.valueType === 'number' },
+    required: function () { return this.valueType === 'number' }
   },
   booleanValue: {
     type: Boolean,
-    required: function () { return this.valueType === 'boolean' },
+    required: function () { return this.valueType === 'boolean' }
   },
   creatorPath: {
     type: String,
@@ -67,6 +70,8 @@ param.methods.paramValue = function () {
       return this.numberValue
     case 'boolean':
       return this.booleanValue
+    case 'array':
+      return this.arrayValue
   }
   return null // if value isnt string, number, or boolean its null
 }

--- a/src/param-api.js
+++ b/src/param-api.js
@@ -66,6 +66,7 @@ exports.getParam = async (req, res) => {
 exports.setParam = async (req, res) => {
   const [callerPath, keyPath, value] = req.body.params
   debug(`callerpath ${callerPath}  keyPath ${keyPath} value ${value}`)
+  debug(req.body.params)
   await Promise.all([
     //coreUtil.logTouch(callerPath, null, req.ip),
     paramUtil.set(keyPath, value, callerPath, req.ip), // also updates subs


### PR DESCRIPTION
## Issues

Improves parameter behavior to more closely match rosmaster

* #25 

## Repro Steps

Create `map_tests.yaml` as shown below:

```
joints: 
  - (JointA, 0)
  - (JointB, 1)
  - (JointC, 16)
map1: {"key": "value", "bar": "foo"}
arr1: [3, 2, 1, {"foo": "bar"}]
map2: {"[0]": 1}
```

Load the map into roscore:

`rosparam load ./map_tests.yaml`

Dump parameters:

`rosparam get /`

```
arr1:
- 3
- 2
- 1
- {foo: bar}
joints: ['(JointA, 0)', '(JointB, 1)', '(JointC, 16)']
map1: {bar: foo, key: value}
map2: {'[0]': 1}
```

There should be no difference in behavior between `vapor_master` and roscore